### PR TITLE
docs(bookme): add post-install ECA security policies runbook

### DIFF
--- a/_bookme/eca-security-policies.md
+++ b/_bookme/eca-security-policies.md
@@ -23,7 +23,7 @@ All three apps need the same set of allowed IPs — the public IPs that the andm
 
 ## 1. BookMe External Client App
 
-The BookMe ECA ships with **PKCE** and **Refresh Token Rotation** already enabled in the new package version — no admin action needed for those.
+The BookMe ECA already has **PKCE** and **Refresh Token Rotation** enabled in your org — Salesforce replicates these developer-side settings from the BookMe source org to every customer org automatically, so no admin action is needed for those.
 
 ### What you need to configure
 
@@ -91,8 +91,8 @@ After saving, confirm each integration still works:
 
 If an integration fails after these changes, the most common cause is a missing or mistyped IP range — double-check the values match exactly.
 
-## Why these settings are not in the package
+## Why these settings need to be configured per-org
 
-Salesforce's app architecture separates *developer settings* (packageable, e.g. PKCE and Refresh Token Rotation on the BookMe ECA) from *subscriber policies* (per-org, e.g. refresh-token validity, IP restrictions, permitted users). The Connected Apps `AMB_INTEGRATION` and `PresentBackendConnected` are not packaged at all — they're created in your org during onboarding — so all of their settings are subscriber-owned.
+Salesforce's app architecture separates *developer-controlled* settings (e.g. PKCE and Refresh Token Rotation on the BookMe ECA — replicated automatically from the andmoney source org) from *subscriber policies* (per-org, e.g. refresh-token validity, IP restrictions, permitted users, run-as user assignment). The Connected Apps `AMB_INTEGRATION` and `PresentBackendConnected` are not packaged or replicated — they're created in your org during onboarding — so all of their settings are subscriber-owned.
 
 This split is documented by Salesforce in [Secure Your Org with External Client Apps](https://developer.salesforce.com/blogs/2025/01/secure-your-org-with-external-client-apps).

--- a/_bookme/eca-security-policies.md
+++ b/_bookme/eca-security-policies.md
@@ -29,17 +29,21 @@ The BookMe ECA ships with **PKCE** and **Refresh Token Rotation** already enable
 
 | Setting | Required value |
 |---|---|
+| Client Credentials Flow | **Enabled**, with a dedicated integration user assigned as **Run As** |
 | Idle Refresh Token TTL | **30 days or less** |
 | Refresh Token IP Range Allow List | The andmoney IPs supplied during onboarding |
+
+> **Note**: Client Credentials Flow is the OAuth flow the andmoney CRM integration uses to authenticate to your org. The flow is only allowed for the user you select as Run As — that user's permissions become the integration's permissions. Use the dedicated BookMe integration user, not a person's account.
 
 ### Steps
 
 1. In Salesforce Setup, search for **External Client App Manager**.
 2. Find **BookMe External Client App** in the list and click **Edit Policies**.
 3. Open the **OAuth Policies** section.
-4. Set **Idle Refresh Token TTL** to `30` days (or lower).
-5. Under **Refresh Token IP Range Allow List**, add one entry per andmoney service egress IP (supplied during onboarding). Use the same IP for both Start and End to add a single address.
-6. Save.
+4. Tick **Enable Client Credentials Flow** and select your dedicated BookMe integration user under **Run As**.
+5. Set **Idle Refresh Token TTL** to `30` days (or lower).
+6. Under **Refresh Token IP Range Allow List**, add one entry per andmoney service egress IP (supplied during onboarding). Use the same IP for both Start and End to add a single address.
+7. Save.
 
 ## 2. AMB_INTEGRATION Connected App
 

--- a/_bookme/eca-security-policies.md
+++ b/_bookme/eca-security-policies.md
@@ -1,42 +1,25 @@
 ---
 layout: default
-title: ECA Security Policies — Post-Install
+title: Salesforce App Security Policies — Post-Install
 nav_order: 14
 parent: BookMe
 ---
 
-# External Client App Security Policies — Post-Install Configuration
+# Salesforce App Security Policies — Post-Install Configuration
 
-After installing or upgrading the **BookMe** managed package, your Salesforce admin must configure two security policies on the `BookMe External Client App` in your org. These policies are not part of the managed package — Salesforce treats them as subscriber policies, so each customer org configures them independently.
+After installing or upgrading the **BookMe** managed package — and during onboarding for **Present** — your Salesforce admin must configure security policies on up to three Salesforce apps used by the andmoney integration:
 
-This is required to comply with Salesforce's AppExchange partner security mandate (deadline 11 May 2026).
+| App | Type | Used by |
+|---|---|---|
+| **BookMe External Client App** | External Client App (ECA) | BookMe CRM integration |
+| **AMB_INTEGRATION** | Connected App | BookMe meeting/attendee sync |
+| **PresentBackendConnected** | Connected App | Present (only customers using Present need this section) |
 
-## What's already configured by the package
-
-The new package version ships with these enabled — no action needed:
-
-- Proof Key for Code Exchange (PKCE)
-- Refresh Token Rotation
-
-## What you need to configure
-
-| Setting | Required value |
-|---|---|
-| Idle Refresh Token TTL | **30 days or less** |
-| Refresh Token IP Range Allow List | The andmoney service egress IPs (see below) |
-
-## Steps
-
-1. In Salesforce Setup, search for **External Client App Manager**.
-2. Find **BookMe External Client App** in the list and click **Edit Policies**.
-3. Open the **OAuth Policies** section.
-4. Set **Idle Refresh Token TTL** to `30` days (or lower).
-5. Under **Refresh Token IP Range Allow List**, add one entry per andmoney service egress IP listed below. Use the same IP for both Start and End to add a single address.
-6. Save.
+These policies are not part of the managed package — Salesforce treats them as subscriber policies, so each customer org configures them independently. This is required to comply with Salesforce's AppExchange partner security mandate (deadline 11 May 2026).
 
 ## andmoney service egress IPs to allow
 
-These are the public IPs that the BookMe CRM integration service uses to reach your Salesforce org. Add all of them.
+All three apps need the same set of allowed IPs. These are the public IPs that the andmoney integration services use to reach your Salesforce org.
 
 | Environment | IP address |
 |---|---|
@@ -45,17 +28,74 @@ These are the public IPs that the BookMe CRM integration service uses to reach y
 
 > **Note**: This list will be kept current at this URL. If andmoney migrates infrastructure, your admin will be notified ahead of time and asked to update the allow list.
 
+## 1. BookMe External Client App
+
+The BookMe ECA ships with **PKCE** and **Refresh Token Rotation** already enabled in the new package version — no admin action needed for those.
+
+### What you need to configure
+
+| Setting | Required value |
+|---|---|
+| Idle Refresh Token TTL | **30 days or less** |
+| Refresh Token IP Range Allow List | All andmoney IPs above |
+
+### Steps
+
+1. In Salesforce Setup, search for **External Client App Manager**.
+2. Find **BookMe External Client App** in the list and click **Edit Policies**.
+3. Open the **OAuth Policies** section.
+4. Set **Idle Refresh Token TTL** to `30` days (or lower).
+5. Under **Refresh Token IP Range Allow List**, add one entry per andmoney service egress IP listed above. Use the same IP for both Start and End to add a single address.
+6. Save.
+
+## 2. AMB_INTEGRATION Connected App
+
+This Connected App is created in your org during BookMe onboarding (not via the managed package). It's used by the andmoney meeting sync service via the JWT Bearer flow.
+
+### What you need to configure
+
+| Setting | Required value | Notes |
+|---|---|---|
+| Permitted Users | **Admin approved users are pre-authorized** | Restricts who can use the app |
+| IP Relaxation | **Enforce IP restrictions** | Required for the IP allow list to take effect |
+| Trusted IP Range / Login IP Ranges | All andmoney IPs above | Same list as the ECA section |
+| Refresh Token Policy | Refresh token is valid for 30 days or less | Mostly informational — JWT Bearer flow doesn't issue refresh tokens, but Salesforce requires the policy to be set |
+
+### Steps
+
+1. In Salesforce Setup, search for **Manage Connected Apps**.
+2. Click **AMB_INTEGRATION**.
+3. Click **Edit Policies**.
+4. Under **OAuth Policies**, set Permitted Users and IP Relaxation as above.
+5. Under **Trusted IP Ranges** (or **Login IP Ranges** depending on your org), add one entry per andmoney IP. Use the same IP for both Start and End.
+6. Set **Refresh Token Policy** to expire after 30 days of inactivity.
+7. Save.
+
+## 3. PresentBackendConnected Connected App
+
+**Skip this section if your org does not use Present.**
+
+This Connected App is created in your org during Present onboarding. It's used by the andmoney Present service via the JWT Bearer flow.
+
+### What you need to configure
+
+The same settings as AMB_INTEGRATION above — Permitted Users (Admin approved), IP Relaxation (Enforce), Trusted IP Range (all andmoney IPs), and Refresh Token Policy (≤30 days).
+
+### Steps
+
+Identical to AMB_INTEGRATION, but click **PresentBackendConnected** in the Manage Connected Apps list.
+
 ## Verifying the configuration
 
-After saving, you can confirm the integration still works by:
+After saving, confirm each integration still works:
 
-1. Triggering a test booking through the BookMe portal.
-2. Confirming a corresponding Event (and any configured related records) appears in your Salesforce org.
+- **BookMe**: trigger a test booking through the BookMe portal and confirm a corresponding Event (and any configured related records) appears in your Salesforce org.
+- **Present**: open a Present-enabled session and confirm meeting/attendee data flows as expected.
 
-If the integration fails after these changes, the most common cause is a missing IP range in step 5 — double-check the values match exactly.
+If an integration fails after these changes, the most common cause is a missing or mistyped IP range — double-check the values match exactly.
 
 ## Why these settings are not in the package
 
-Salesforce's External Client App architecture separates *developer settings* (packageable) from *subscriber policies* (per-org). PKCE and Refresh Token Rotation are developer settings; refresh-token validity windows and IP restrictions are subscriber policies that each org's admin owns.
+Salesforce's app architecture separates *developer settings* (packageable, e.g. PKCE and Refresh Token Rotation on the BookMe ECA) from *subscriber policies* (per-org, e.g. refresh-token validity, IP restrictions, permitted users). The Connected Apps `AMB_INTEGRATION` and `PresentBackendConnected` are not packaged at all — they're created in your org during onboarding — so all of their settings are subscriber-owned.
 
 This split is documented by Salesforce in [Secure Your Org with External Client Apps](https://developer.salesforce.com/blogs/2025/01/secure-your-org-with-external-client-apps).

--- a/_bookme/eca-security-policies.md
+++ b/_bookme/eca-security-policies.md
@@ -26,7 +26,7 @@ All three apps need the same set of allowed IPs. These are the public IPs that t
 | andmoney production | `<TBD>` |
 | andmoney test | `<TBD>` |
 
-> **Note**: This list will be kept current at this URL. If andmoney migrates infrastructure, your admin will be notified ahead of time and asked to update the allow list.
+> **Note**: If andmoney migrates infrastructure, your admin will be notified ahead of time and asked to update the allow list.
 
 ## 1. BookMe External Client App
 

--- a/_bookme/eca-security-policies.md
+++ b/_bookme/eca-security-policies.md
@@ -17,16 +17,9 @@ After installing or upgrading the **BookMe** managed package — and during onbo
 
 These policies are not part of the managed package — Salesforce treats them as subscriber policies, so each customer org configures them independently. This is required to comply with Salesforce's AppExchange partner security mandate (deadline 11 May 2026).
 
-## andmoney service egress IPs to allow
+## andmoney service egress IPs
 
-All three apps need the same set of allowed IPs. These are the public IPs that the andmoney integration services use to reach your Salesforce org.
-
-| Environment | IP address |
-|---|---|
-| andmoney production | `<TBD>` |
-| andmoney test | `<TBD>` |
-
-> **Note**: If andmoney migrates infrastructure, your admin will be notified ahead of time and asked to update the allow list.
+All three apps need the same set of allowed IPs — the public IPs that the andmoney integration services use to reach your Salesforce org. These are not published here for security reasons; they will be supplied as part of your onboarding handoff. If you need them re-sent, ask your andmoney contact.
 
 ## 1. BookMe External Client App
 
@@ -37,7 +30,7 @@ The BookMe ECA ships with **PKCE** and **Refresh Token Rotation** already enable
 | Setting | Required value |
 |---|---|
 | Idle Refresh Token TTL | **30 days or less** |
-| Refresh Token IP Range Allow List | All andmoney IPs above |
+| Refresh Token IP Range Allow List | The andmoney IPs supplied during onboarding |
 
 ### Steps
 
@@ -45,7 +38,7 @@ The BookMe ECA ships with **PKCE** and **Refresh Token Rotation** already enable
 2. Find **BookMe External Client App** in the list and click **Edit Policies**.
 3. Open the **OAuth Policies** section.
 4. Set **Idle Refresh Token TTL** to `30` days (or lower).
-5. Under **Refresh Token IP Range Allow List**, add one entry per andmoney service egress IP listed above. Use the same IP for both Start and End to add a single address.
+5. Under **Refresh Token IP Range Allow List**, add one entry per andmoney service egress IP (supplied during onboarding). Use the same IP for both Start and End to add a single address.
 6. Save.
 
 ## 2. AMB_INTEGRATION Connected App
@@ -58,7 +51,7 @@ This Connected App is created in your org during BookMe onboarding (not via the 
 |---|---|---|
 | Permitted Users | **Admin approved users are pre-authorized** | Restricts who can use the app |
 | IP Relaxation | **Enforce IP restrictions** | Required for the IP allow list to take effect |
-| Trusted IP Range / Login IP Ranges | All andmoney IPs above | Same list as the ECA section |
+| Trusted IP Range / Login IP Ranges | The andmoney IPs supplied during onboarding | Same list as the ECA section |
 | Refresh Token Policy | Refresh token is valid for 30 days or less | Mostly informational — JWT Bearer flow doesn't issue refresh tokens, but Salesforce requires the policy to be set |
 
 ### Steps
@@ -67,7 +60,7 @@ This Connected App is created in your org during BookMe onboarding (not via the 
 2. Click **AMB_INTEGRATION**.
 3. Click **Edit Policies**.
 4. Under **OAuth Policies**, set Permitted Users and IP Relaxation as above.
-5. Under **Trusted IP Ranges** (or **Login IP Ranges** depending on your org), add one entry per andmoney IP. Use the same IP for both Start and End.
+5. Under **Trusted IP Ranges** (or **Login IP Ranges** depending on your org), add one entry per andmoney IP (supplied during onboarding). Use the same IP for both Start and End.
 6. Set **Refresh Token Policy** to expire after 30 days of inactivity.
 7. Save.
 
@@ -79,7 +72,7 @@ This Connected App is created in your org during Present onboarding. It's used b
 
 ### What you need to configure
 
-The same settings as AMB_INTEGRATION above — Permitted Users (Admin approved), IP Relaxation (Enforce), Trusted IP Range (all andmoney IPs), and Refresh Token Policy (≤30 days).
+The same settings as AMB_INTEGRATION above — Permitted Users (Admin approved), IP Relaxation (Enforce), Trusted IP Range (the andmoney IPs supplied during onboarding), and Refresh Token Policy (≤30 days).
 
 ### Steps
 

--- a/_bookme/eca-security-policies.md
+++ b/_bookme/eca-security-policies.md
@@ -1,0 +1,61 @@
+---
+layout: default
+title: ECA Security Policies — Post-Install
+nav_order: 14
+parent: BookMe
+---
+
+# External Client App Security Policies — Post-Install Configuration
+
+After installing or upgrading the **BookMe** managed package, your Salesforce admin must configure two security policies on the `BookMe External Client App` in your org. These policies are not part of the managed package — Salesforce treats them as subscriber policies, so each customer org configures them independently.
+
+This is required to comply with Salesforce's AppExchange partner security mandate (deadline 11 May 2026).
+
+## What's already configured by the package
+
+The new package version ships with these enabled — no action needed:
+
+- Proof Key for Code Exchange (PKCE)
+- Refresh Token Rotation
+
+## What you need to configure
+
+| Setting | Required value |
+|---|---|
+| Idle Refresh Token TTL | **30 days or less** |
+| Refresh Token IP Range Allow List | The andmoney service egress IPs (see below) |
+
+## Steps
+
+1. In Salesforce Setup, search for **External Client App Manager**.
+2. Find **BookMe External Client App** in the list and click **Edit Policies**.
+3. Open the **OAuth Policies** section.
+4. Set **Idle Refresh Token TTL** to `30` days (or lower).
+5. Under **Refresh Token IP Range Allow List**, add one entry per andmoney service egress IP listed below. Use the same IP for both Start and End to add a single address.
+6. Save.
+
+## andmoney service egress IPs to allow
+
+These are the public IPs that the BookMe CRM integration service uses to reach your Salesforce org. Add all of them.
+
+| Environment | IP address |
+|---|---|
+| andmoney production | `<TBD>` |
+| andmoney test | `<TBD>` |
+
+> **Note**: This list will be kept current at this URL. If andmoney migrates infrastructure, your admin will be notified ahead of time and asked to update the allow list.
+
+## Verifying the configuration
+
+After saving, you can confirm the integration still works by:
+
+1. Triggering a test booking through the BookMe portal.
+2. Confirming a corresponding Event (and any configured related records) appears in your Salesforce org.
+
+If the integration fails after these changes, the most common cause is a missing IP range in step 5 — double-check the values match exactly.
+
+## Why these settings are not in the package
+
+Salesforce's External Client App architecture separates *developer settings* (packageable) from *subscriber policies* (per-org). PKCE and Refresh Token Rotation are developer settings; refresh-token validity windows and IP restrictions are subscriber policies that each org's admin owns.
+
+This split is documented by Salesforce in [Secure Your Org with External Client Apps](https://developer.salesforce.com/blogs/2025/01/secure-your-org-with-external-client-apps).


### PR DESCRIPTION
## Summary
- Adds `_bookme/eca-security-policies.md`: a customer-admin-facing runbook for the security policies that customer admins must configure per-org for the andmoney Salesforce apps. Covers three apps in one doc:
  - **BookMe External Client App** — Idle Refresh Token TTL and Refresh Token IP Range Allow List (PKCE + RT rotation already enabled by the new package)
  - **AMB_INTEGRATION** Connected App — Permitted Users, IP Relaxation, Trusted IP Range, Refresh Token Policy
  - **PresentBackendConnected** Connected App — same as AMB_INTEGRATION (only Present customers)
- Lists the andmoney CRM service AKS egress IPs that customer admins must allow — currently `<TBD>` placeholders pending lookup before publication.

## Why
Closes the post-install-guidance half of [andmoneyaps/Roadmap#438](https://github.com/andmoneyaps/Roadmap/issues/438). Salesforce's app architecture splits OAuth configuration into developer settings (packageable) and subscriber policies (per-org). PKCE and RT Rotation on the BookMe ECA are developer settings — covered by the new package version. Everything else — refresh-token validity windows, IP restrictions, permitted users — is per-org. The two Connected Apps (`AMB_INTEGRATION`, `PresentBackendConnected`) aren't packaged at all, so all their settings are subscriber-owned. This runbook gives customer admins one place to find the steps and values needed to satisfy the [Salesforce AppExchange partner mandate](https://www.gomeddo.com/blog/keeping-gomeddo-secure-how-were-responding-to-salesforces-new-security-requirements) by the 2026-05-11 deadline.

## Test plan
- [ ] Render the page locally (Jekyll) and confirm frontmatter / nav placement
- [ ] Verify the external link to the Salesforce dev blog resolves
- [ ] Replace the `<TBD>` IP addresses in the "andmoney service egress IPs" table with real values before publishing (lookup via `az aks show -g rg-{test,prod}-cluster -n aks-andmoney-{test,prod}`)
- [ ] Verify Setup-UI labels in the steps match the actual Salesforce UI for all three apps (PR author or first reviewer with org access)
- [ ] Confirm the PresentBackendConnected section is appropriate to keep in the BookMe parent (vs. moving the Present subsection to `_present/`)

## Rollback
Revert this PR — all changes are new additions.

## Impact
Affects `_bookme/` (1 new file). No code, no CI, no existing-page changes.

Refs andmoneyaps/Roadmap#438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added post-install/post-upgrade security guide for BookMe, AMB_INTEGRATION, and Present connected apps (Present optional).
  * Specifies required admin OAuth/connected-app settings: enable client-credential flow with a dedicated integration user, PKCE/refresh-rotation present, idle refresh token TTL ≤30 days, refresh-token IP allow-lists, permitted users, IP relaxation (enforce), and trusted/login IPs.
  * Includes verification steps, troubleshooting note, and AppExchange compliance deadline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->