### PR TITLE
docs(present): add release notes for version 1.34

### DIFF
--- a/_present/release-notes.md
+++ b/_present/release-notes.md
@@ -26,7 +26,7 @@ Resolved an issue where "Sektioner" would occasionally appear twice when switchi
 > **Subscriber Package Version ID:** `04tP7000002xIqzIAE`
 >
 > **Installation URL:**
-> `https://[YOUR_DOMAIN].lightning.force.com/packagingSetupUI/ipLanding.app?apvId=`
+> `https://[YOUR_DOMAIN].lightning.force.com/packagingSetupUI/ipLanding.app?apvId=04tP7000002xIqzIAE`
 >
 > **Note:** Replace `[YOUR_DOMAIN]` with your organization's Salesforce domain.
 

--- a/_present/release-notes.md
+++ b/_present/release-notes.md
@@ -23,7 +23,7 @@ Resolved an issue where "Sektioner" would occasionally appear twice when switchi
 
 ### Installation
 
-> **Subscriber Package Version ID:** *(to be added after release)*
+> **Subscriber Package Version ID:** `04tP7000002xIqzIAE`
 >
 > **Installation URL:**
 > `https://[YOUR_DOMAIN].lightning.force.com/packagingSetupUI/ipLanding.app?apvId=`
@@ -41,6 +41,7 @@ Resolved an issue where "Sektioner" would occasionally appear twice when switchi
 **Bulk Slide Selection** — Select or deselect multiple slides at once using "Vælg alle" and "Fravælg alle" buttons at both section and subsection levels. See [Bulk Slide Selection]({{ site.baseurl }}/present/bulk-slide-selection/) for details.
 
 **Label Filter Configuration** — New LWC config options for controlling the label filter:
+
 - `labelWhitelist` — Restrict the filter dropdown to only show specific labels
 - `hideLabelFilter` — Completely hide the label filter for use-cases where it's not relevant
 
@@ -120,9 +121,11 @@ Fixed a defect where template operations (new uploads or reordering) incorrectly
 ---
 
 ## Present - Version 1.27
+
 This version of Present includes several releases of new features and bug fixes.
 
 ### Release Date - 2025-10-21
+
 This release includes the following updates:
 
 **Interactive slides**
@@ -144,11 +147,13 @@ Note: Active links dont work in Salesforce preview feature!
 Allows admins to transform the data from Salesforce fields before inserting them into the customer presentations. This gives control over text formatting without changing the source data in Salesforce, and creates new opportunities for the usage of tags.
 
 ### Release Date - 2025-05-06
+
 This release includes the following updates:
 
 > **Subscriber Package Version Id**: `04tP7000001U8dtIAC`
 >
 > **Install link**:
+>
 > - `https://[YOUR_DOMAIN].lightning.force.com/packagingSetupUI/ipLanding.app?apvId=04tP7000001U8dtIAC`.
 >
 > Remember to use your org's URL instead of [YOUR_DOMAIN].
@@ -157,17 +162,19 @@ This release includes the following updates:
 
 **Changes** - Removed validation rule that disallowed inactive templates to be activated again (in case a template was falsely deactivated)
 
-
 ## Present - Version 1.24
+
 This version of Present delivers important quality-of-life enhancements that improve consistency,
 usability, and clarity across the application.
 
 ### Release Date - 2025-03-01
+
 This release includes the following updates:
 
 > **Subscriber Package Version Id**: `04tP7000001HSSLIA4`
 >
 > **Install link**:
+>
 > - `https://[YOUR_DOMAIN].lightning.force.com/packagingSetupUI/ipLanding.app?apvId=04tP7000001HSSLIA4`.
 >
 > Remember to use your org's URL instead of [YOUR_DOMAIN].
@@ -175,6 +182,7 @@ This release includes the following updates:
 **General bugfixes** — This release includes several bug fixes to improve the overall stability and performance of the application.
 
 ### Improvements {id="improvements_2"}
+
 **Enhanced Error Messages and Permission checks**
 
 To help with faster troubleshooting and provide better guidance,
@@ -183,24 +191,29 @@ Additionally,
 we have improved permission checks to ensure that users have the necessary access to perform specific actions.
 
 ### Bug fixes {id="bug-fixes_2"}
+
 **Tag Name Case Sensitivity**
 
 A fix has been applied to ensure that tag comparisons are case-insensitive.
 This update prevents inconsistencies related to tag case sensitivity.
 
 ### Technical details {id="technical-details_2"}
+
 new Version — The application has been updated to version 1.24.
 
 ## Present - Version 1.23
+
 This version of Present delivers important quality-of-life enhancements that improve consistency,
 usability, and clarity across the application.
 
 ### Release Date - 2025-02-03
+
 This release includes the following updates:
 
 > **Subscriber Package Version Id**: `04tP7000000vNSwIAM`
 >
 > **Install link**:
+>
 > - `https://[YOUR_DOMAIN].lightning.force.com/packagingSetupUI/ipLanding.app?apvId=04tP7000000vNSwIAM`.
 >
 > Remember to use your org's URL instead of [YOUR_DOMAIN].
@@ -215,22 +228,26 @@ more actionable feedback for troubleshooting.
 New labels and subtle UI adjustments have been introduced to boost the overall user experience.
 
 ### New features {id="new-features_1"}
+
 **UI Enhancements and Additional Labels**
 
 We have implemented additional labels and refined UI elements to improve navigation and clarity within the application. These adjustments make it easier for users to locate features and understand interface elements.
 
 ### Improvements {id="improvements_1"}
+
 **Enhanced Error Messages**
 
 To assist in faster troubleshooting and provide better guidance, error messages now offer more detailed insights and clear instructions.
 
 ### Bug fixes {id="bug-fixes_1"}
+
 **Tag Name Case Sensitivity**
 
 A fix has been applied to ensure that tag comparisons are case-insensitive.
 This update prevents inconsistencies related to tag case sensitivity.
 
 ### Technical details {id="technical-details_1"}
+
 Version bump — The application has been updated to version 1.23.
 
 ## Present - Version 1.21
@@ -240,10 +257,11 @@ This version of Present introduces crucial quality-of-life features.
 ### Release Date - 2024-11-15
 
 This release includes the following updates:
-* **Present Validation Tool**—Validate your templates before uploading them in Present. The new tool helps you identify any issues with your templates before they are uploaded to Present
-* **Deactivation of old templates**—We now support deactivation/archiving of templates in Present. This will keep your templates' metadata when deactivating templates used in reporting
-* **Tag mapping now supports custom and nested sObjects**—Map custom and/or nested objects in Salesforce to tags in your templates
-* **Translations**—We have added translations for the Present app in English, Norwegian and Swedish
+
+- **Present Validation Tool**—Validate your templates before uploading them in Present. The new tool helps you identify any issues with your templates before they are uploaded to Present
+- **Deactivation of old templates**—We now support deactivation/archiving of templates in Present. This will keep your templates' metadata when deactivating templates used in reporting
+- **Tag mapping now supports custom and nested sObjects**—Map custom and/or nested objects in Salesforce to tags in your templates
+- **Translations**—We have added translations for the Present app in English, Norwegian and Swedish
 
 ### New features
 
@@ -252,11 +270,9 @@ This release includes the following updates:
 The Present Test Tool allows you to test and validate your templates before uploading them in Present.
 This tool helps you to identify any issues with your templates before they are uploaded to Present. It can report on missing data in chart, incorrect tags, and more. It allows template authors to get info, warnings or errors on the slides they create.
 
-
 <img alt="Validate Button" src="{{ site.baseurl }}/assets/images/present/validate_button.png" width="600"/>
 <img alt="validate Template" src="{{ site.baseurl }}/assets/images/present/validate_template.png" width="600"/>
 <img alt="Validation Results" src="{{ site.baseurl }}/assets/images/present/validation_results.png" width="600"/>
-
 
 - **Deactivation of old templates**
 
@@ -264,13 +280,11 @@ We now support deactivation/archiving of templates in Present. This will keep yo
 
 <img alt="Deactivate template" src="{{ site.baseurl }}/assets/images/present/deactivate.png" width="300"/>
 
-
 - **Tag mapping now supports custom and nested sObjects**
 
 This feature allows you to map fields from custom and nested objects in Salesforce to tags in your templates.
 
 <img alt="Extended Tag Mapping" src="{{ site.baseurl }}/assets/images/present/tag_mapping_extended.png" width="600"/>
-
 
 ### Improvements
 
@@ -285,6 +299,7 @@ We have added translations for the Present app in English, Norwegian and Swedish
   We have fixed issues where the app would crash when uploading a template with a large number of slides.
 
 ### Technical details
+
 - Subscriber Package Version Id: `04tP7000000vNSwIAM`
 - Install link: `https://[YOUR_DOMAIN].lightning.force.com/packagingSetupUI/ipLanding.app?apvId=04tP7000000vNSwIAM`
 

--- a/_present/release-notes.md
+++ b/_present/release-notes.md
@@ -8,6 +8,30 @@ collection: present
 
 # Release Notes—Present
 
+## Version 1.33
+
+**Release Date:** May 2026
+
+### Bug Fixes
+
+**Duplicate Sections in Present Tab**
+
+Resolved an issue where "Sektioner" would occasionally appear twice when switching between sub-tabs (e.g. "Private Banking" → "Pension") in the Present tab.
+
+- **Impact:** Sections rendered twice for users who switched tabs while the initial page load was still in progress, making the presentation view appear duplicated
+- **Resolution:** Added a request ID guard to `populateArraysWithDataFromService()` to discard stale API responses when a newer request has already been initiated
+
+### Installation
+
+> **Subscriber Package Version ID:** *(to be added after release)*
+>
+> **Installation URL:**
+> `https://[YOUR_DOMAIN].lightning.force.com/packagingSetupUI/ipLanding.app?apvId=`
+>
+> **Note:** Replace `[YOUR_DOMAIN]` with your organization's Salesforce domain.
+
+---
+
 ## Version 1.32
 
 **Release Date:** January 2026

--- a/_present/release-notes.md
+++ b/_present/release-notes.md
@@ -8,7 +8,7 @@ collection: present
 
 # Release Notes—Present
 
-## Version 1.33
+## Version 1.34
 
 **Release Date:** May 2026
 


### PR DESCRIPTION
Documents the fix (AMFM-701) for duplicate sections appearing when switching tabs during initial page load in the Present tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate "Sektioner" sections appearing in the Present tab.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andmoneyaps/docs/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->