### PR TITLE
docs(meet): add automatic summary recovery release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ permalink: /changelog/
 
 This changelog tracks significant updates and changes to the AndMoney documentation.
 
+## June 2026
+
+### Added
+- [Assist Release Notes]({{ site.baseurl }}/meet/release-notes/) — added **Automatic summary recovery**: meetings that end without pressing *End meeting* now still produce a summary in Salesforce
+
 ## April 2026
 
 ### Added

--- a/_meet/release-notes.md
+++ b/_meet/release-notes.md
@@ -13,7 +13,7 @@ Assist is continuously improved and deployed. This page highlights notable updat
 
 ### Reliability
 
-- **Automatic summary recovery** — If a meeting ends without the advisor pressing **End meeting** (for example, the laptop is closed or the browser tab is shut), Assist now automatically detects the unfinished meeting and generates its summary anyway. The summary appears in Salesforce exactly as it would have if the meeting had been ended normally, so advisors no longer lose the record of a real customer conversation. Recovery happens behind the scenes shortly after the meeting is detected as abandoned, while the meeting's transcript is still available, and never produces a duplicate summary.
+- **Automatic summary recovery** — If a meeting ends without the advisor pressing **End meeting** (for example, the laptop is closed or the browser tab is shut), Assist now automatically detects the unfinished meeting and generates its summary anyway. The summary appears in Salesforce exactly as it would have if the meeting had been ended normally, so advisors no longer lose the record of a real customer conversation. Recovery happens behind the scenes shortly after the meeting is detected as abandoned, while the meeting's transcript is still available — so eligible meetings still end up with a summary instead of none.
 
 ## May 2026
 

--- a/_meet/release-notes.md
+++ b/_meet/release-notes.md
@@ -9,6 +9,12 @@ parent: Assist
 
 Assist is continuously improved and deployed. This page highlights notable updates and newly published documentation.
 
+## June 2026
+
+### Reliability
+
+- **Automatic summary recovery** — If a meeting ends without the advisor pressing **End meeting** (for example, the laptop is closed or the browser tab is shut), Assist now automatically detects the unfinished meeting and generates its summary anyway. The summary appears in Salesforce exactly as it would have if the meeting had been ended normally, so advisors no longer lose the record of a real customer conversation. Recovery happens behind the scenes shortly after the meeting is detected as abandoned, while the meeting's transcript is still available, and never produces a duplicate summary.
+
 ## May 2026
 
 ### Configuration

--- a/release-news.md
+++ b/release-news.md
@@ -3,6 +3,12 @@ layout: home
 title: Release news
 nav_order: 2
 ---
+## June 2026
+
+### _Assist_
+
+- **Automatic summary recovery**: Meetings that end without the advisor pressing **End meeting** (laptop closed, browser tab shut) are now automatically detected and still get a summary written to Salesforce — no advisor action needed and no duplicate summary. See [Assist Release Notes]({{ site.baseurl }}/meet/release-notes/).
+
 ## March 2026
 
 ### _BookMe_


### PR DESCRIPTION
## Summary
- **Assist release notes** (`_meet/release-notes.md`) — new June 2026 *Reliability* entry: meetings that end without pressing **End meeting** (laptop closed, tab shut) now still get a summary in Salesforce, with no duplicate summary
- **Release news** (`release-news.md`) — June 2026 Assist entry pointing at the release note
- **Documentation changelog** (`CHANGELOG.md`) — June 2026 *Added* entry

## Why
Roadmap#517 (Documentation) for Feature Roadmap#486 — *automatic summary recovery for ungracefully-ended meetings*. The task's "Release notes / changelog" acceptance item. There is **no user-facing UI change** (the issue marks user/business docs N/A), so these entries describe the customer-observable *effect* — an abandoned meeting still produces its summary — framed as a reliability improvement, and deliberately avoid the bare word "recovery" so it isn't confused with the existing "Session Recovery" (disconnect) feature.

## Test plan
- [ ] Docs build — `bundle exec jekyll serve` renders the June 2026 entries on the Assist release notes, Release news, and Changelog pages
- [ ] Wording review — a PO/maintainer confirms the customer-facing framing reads correctly

## Rollback
Revert this PR — documentation-only, no runtime impact.

## Impact
Affects `_meet/release-notes.md`, `release-news.md`, `CHANGELOG.md` (3 files).

Closes andmoneyaps/Roadmap#517

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic summary recovery: Meetings that end without explicitly pressing "End meeting" will automatically generate summaries in Salesforce without creating duplicates; transcripts remain available for reference.

* **Reliability**
  * Abandoned or prematurely ended meetings are detected and processed shortly after detection to ensure eligible meetings still receive summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->