### PR TITLE
docs: clarify empty service level vs trigger semantics

### DIFF
--- a/_bookme/available-timeslots-guide.md
+++ b/_bookme/available-timeslots-guide.md
@@ -103,12 +103,18 @@ A service group is triggered when the booking request matches its configured cri
 - **Customer category** --- the customer segment
 - **Customer location** --- where the customer is located
 
+A criterion that is left empty acts as a wildcard: the group matches any value for that dimension. A group with no criteria at all is triggered by every booking request.
+
 **Example**: A "National Mortgage Team" service group might be triggered whenever a customer requests a mortgage meeting. The group contains five advisors from various branches who can serve the customer via Online or Telephone meetings.
 
 Service groups have a **service level** that defines:
 - Which meeting types the group offers (e.g., Online and Telephone only)
 - Which locations the group can serve for physical meetings (if any)
 - An optional maximum meeting time per day for group members
+
+**Important:** Unlike the trigger criteria, an empty service level is *restrictive*, not a wildcard:
+- If **no meeting types** are selected, the group offers no timeslots at all --- even when its trigger matches. A newly created service group starts in this state, so meeting types must always be configured.
+- If **no locations** are selected, the group cannot offer Physical meetings. Remote meeting types (Online, Telephone, Off-site) still work, so locations can be left empty for purely remote groups.
 
 ### How They Work Together
 

--- a/_bookme/service-competence-groups.md
+++ b/_bookme/service-competence-groups.md
@@ -115,6 +115,7 @@ This will search for available advisors from configured Service Groups.
     - Determine what should be offered to customers beyond current services.
     - Customers can access selected locations in addition to their regular department.
     - Meeting themes must fulfill the activation rules.
+    - **Important:** At least one meeting type must be selected --- a service group with no meeting types configured will not offer any time slots, even when its activation rules match. Locations are only required if the group should offer physical meetings; they can be left empty for purely remote groups (Online/Telephone).
 
 4. **Set Service Level by Location/Meeting Type:**
 


### PR DESCRIPTION
## Summary

Documents a non-obvious asymmetry in service group configuration, discovered while tracing the availability code:

- **Trigger criteria** (theme / customer category / location): empty = wildcard, matches everything.
- **Service level** (meeting types / locations): empty = restrictive, allows nothing in that dimension.

Concretely:
- A service group with no meeting types configured offers **no timeslots at all**, even when its trigger matches. This is the default state for newly created groups, and nothing validates against it — making it an easy misconfiguration.
- Empty locations only disable **Physical** meetings; remote types (Online/Telephone/Off-site) still work, so locations can be left empty for purely remote groups.

## Changes
- `_bookme/available-timeslots-guide.md`: wildcard note on trigger criteria + restrictive-semantics note on service level.
- `_bookme/service-competence-groups.md`: setup step 3 now warns that at least one meeting type is required and locations are optional for remote-only groups.

Companion internal PR: andmoneyaps/docs-internal (same branch name).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Clarified how service groups trigger timeslot availability and interact with service level constraints.
* Added guidance that at least one meeting type must be configured for a service group to offer timeslots.
* Explained location configuration options for remote meetings.
* Clarified behavior of empty trigger criteria and service level settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->